### PR TITLE
Feat/column filter, operations api, and rename `report` apis to `report-page`

### DIFF
--- a/da-project-backend/app/api.py
+++ b/da-project-backend/app/api.py
@@ -15,48 +15,48 @@ from .models import (
 app = FastAPI()
 
 
-@app.get("/api/report")
-def get_all_reports(
+@app.get("/api/report-page")
+def get_all_report_pages(
     session: SessionDep,
     offset: int = 0,
     limit: Annotated[int, Query(le=100)] = 100,
 ) -> List[PageResponse]:
-    reports = session.exec(select(Page).offset(offset).limit(limit)).all()
-    return PageResponse.from_pages(reports)
+    pages = session.exec(select(Page).offset(offset).limit(limit)).all()
+    return PageResponse.from_pages(pages)
 
 
-@app.get("/api/report/{report_id}")
-def get_report(
-    report_id: int,
+@app.get("/api/report-page/{page_id}")
+def get_report_page(
+    page_id: int,
     session: SessionDep,
 ) -> PageResponse:
-    report = session.get(Page, report_id)
-    if not report:
-        raise HTTPException(status_code=404, detail="Report not found")
-    return PageResponse.from_page(report)
+    page = session.get(Page, page_id)
+    if not page:
+        raise HTTPException(status_code=404, detail="Report page not found")
+    return PageResponse.from_page(page)
 
 
-@app.get("/api/report/{report_id}/comments")
-def get_report_remarks(
-    report_id: int,
+@app.get("/api/report-page/{page_id}/comments")
+def get_page_comments(
+    page_id: int,
     session: SessionDep,
     offset: int = 0,
     limit: Annotated[int, Query(le=100)] = 100,
 ) -> List[CommentResponse]:
-    remarks = session.exec(
-        select(Comment).where(Comment.page_id == report_id).offset(offset).limit(limit)
+    comments = session.exec(
+        select(Comment).where(Comment.page_id == page_id).offset(offset).limit(limit)
     ).all()
-    return CommentResponse.from_comments(remarks)
+    return CommentResponse.from_comments(comments)
 
 
-@app.post("/api/report/{report_id}/comments")
-def post_report_remark(
-    report_id: int,
-    remark: CommentCreate,
+@app.post("/api/report-page/{page_id}/comments")
+def post_page_comment(
+    page_id: int,
+    comment: CommentCreate,
     session: SessionDep,
 ) -> CommentResponse:
-    db_remark = remark.validate_to_comment(report_id)
-    session.add(db_remark)
+    db_comment = comment.validate_to_comment(page_id)
+    session.add(db_comment)
     session.commit()
-    session.refresh(db_remark)
-    return CommentResponse.from_comment(db_remark)
+    session.refresh(db_comment)
+    return CommentResponse.from_comment(db_comment)

--- a/da-project-backend/app/api.py
+++ b/da-project-backend/app/api.py
@@ -1,3 +1,5 @@
+import enum
+from collections import Counter
 from typing import Annotated, List
 
 from fastapi import FastAPI, HTTPException, Query
@@ -6,8 +8,8 @@ from sqlmodel import col, select
 from .database import SessionDep
 from .models import (
     Column,
-    ColumnResponse,
     ColumnDataType,
+    ColumnResponse,
     Comment,
     CommentCreate,
     CommentResponse,
@@ -65,7 +67,7 @@ def post_page_comment(
     return CommentResponse.from_comment(db_comment)
 
 
-@app.get("/api/report-page/{page_id}/columns")
+@app.get("/api/report-page/{page_id}/column")
 def get_report_page_columns(
     page_id: int,
     session: SessionDep,
@@ -93,3 +95,80 @@ def get_report_page_columns(
         )
         for label, row_type, rows in res
     ]
+
+
+class ColumnOperation(enum.StrEnum):
+    SUM = "sum"
+    MEAN = "mean"
+    MEDIAN = "median"
+    MODE = "mode"
+    MAX = "max"
+    MIN = "min"
+
+
+@app.get(
+    "/api/report-page/{page_id}/column/{label}",
+    description="""
+If no operation is specified, this will return `array<string> | null`.
+Response type is dependent on optional operation query param.
+
+If operation is set, the row data type in the db must be `"num"` or else this
+will return `null`.
+
+    operation = response type
+    max = number
+    mean = number
+    median = number
+    min = number
+    mode = array<number>
+    sum = number
+""",
+)
+def get_report_page_column_data_by_label(
+    page_id: int,
+    label: str,
+    session: SessionDep,
+    operation: ColumnOperation | None = None,
+) -> list[str] | list[float] | float | None:
+    statement = (
+        select(Column.rows, Column.dtype)
+        .select_from(Page, Column)
+        .where(Page.page_id == page_id)
+        .where(Column.report_id == Page.report_id)
+        .where(Column.label == label)
+    )
+    res = session.exec(statement).first()
+    if not res:
+        return None
+    (row, dtype) = res
+    if not row:
+        return None
+    row_data = row.split(",")
+    if not operation:
+        return row_data
+    if dtype != ColumnDataType.NUMBER:
+        return None
+    row_data = list(map(float, row_data))
+    match operation:
+        case ColumnOperation.MAX:
+            return max(row_data)
+        case ColumnOperation.MEAN:
+            return sum(row_data) / len(row_data)
+        case ColumnOperation.MEDIAN:
+            row_data.sort()
+            n = len(row_data)
+            if n % 2 != 0:
+                return row_data[n // 2]
+            else:
+                mid_1 = row_data[(n // 2) - 1]
+                mid_2 = row_data[(n // 2)]
+                return (mid_1 + mid_2) / 2
+        case ColumnOperation.MIN:
+            return min(row_data)
+        case ColumnOperation.MODE:
+            counts = Counter(row_data)
+            max_freq = max(counts.values())
+            modes = [key for key, val in counts.items() if val == max_freq]
+            return modes
+        case ColumnOperation.SUM:
+            return sum(row_data)

--- a/da-project-backend/app/database.py
+++ b/da-project-backend/app/database.py
@@ -3,10 +3,14 @@ from typing import Annotated
 from fastapi import Depends
 from sqlmodel import Session, SQLModel, create_engine
 
-sqlite_file_name = "database.db"
+sqlite_file_name = "db.db"
 sqlite_url = f"sqlite:///{sqlite_file_name}"
-connect_args = {"check_same_thread": False}
-engine = create_engine(sqlite_url, connect_args=connect_args)
+engine = create_engine(
+    sqlite_url,
+    connect_args={
+        "check_same_thread": False,
+    },
+)
 
 
 def create_db_and_tables():

--- a/da-project-backend/app/models.py
+++ b/da-project-backend/app/models.py
@@ -112,7 +112,6 @@ class Column(ColumnFields, table=True):
 
 
 class ColumnResponse(BaseModel):
-    id: int
     label: str
     rows: list[str]
     row_type: str
@@ -120,7 +119,6 @@ class ColumnResponse(BaseModel):
     @staticmethod
     def from_column(column: Column) -> "ColumnResponse":
         return ColumnResponse(
-            id=column.column_id if column.column_id is not None else 0,
             label=column.label,
             rows=column.rows.split(",") if column.rows else [],
             row_type=column.dtype,

--- a/da-project-backend/app/models.py
+++ b/da-project-backend/app/models.py
@@ -94,8 +94,8 @@ class PageResponse(BaseModel):
 
 ## COLUMN MODELS
 class ColumnDataType(enum.StrEnum):
-    NUMBER = "NUMBER"
     BOOLEAN = "BOOLEAN"
+    NUMBER = "NUMBER"
     STRING = "STRING"
 
 
@@ -104,7 +104,9 @@ class ColumnFields(SQLModel):
     report_id: int = Field(foreign_key="report.report_id", ondelete="CASCADE")
     label: str = Field(default="")
     rows: str | None = Field(default=None)
-    dtype: ColumnDataType = Field(sa_column=Col(Enum(ColumnDataType)))
+    dtype: ColumnDataType = Field(
+        default=ColumnDataType.STRING, sa_column=Col(Enum(ColumnDataType))
+    )
 
 
 class Column(ColumnFields, table=True):


### PR DESCRIPTION
closes #6 
closes #7 

---
## changes
1. get column data by label api
2. optional operations done over the api above

### demo

https://github.com/user-attachments/assets/4e9b1bc4-20b8-4aaf-9dec-cbc4fa2fbba0

## etc
1.  Rename `report` api's to `report-page`