### PR TITLE
Feat/complete crud apis

### DIFF
--- a/da-project-backend/app/api.py
+++ b/da-project-backend/app/api.py
@@ -21,6 +21,7 @@ from .models import (
     PageResponse,
     Report,
     ReportCreate,
+    ReportUpdate,
     ReportResponse,
 )
 
@@ -73,6 +74,43 @@ def add_report(
     session.commit()
     session.refresh(db_report)
     return ReportResponse.from_report(db_report)
+
+
+@app.patch("/api/report/{report_id}")
+def update_report(
+    report_id: int,
+    update: ReportUpdate,
+    session: SessionDep,
+):
+    original = session.exec(
+        select(Report).where(Report.report_id == report_id).offset(0).limit(1)
+    ).first()
+    if not original:
+        raise HTTPException(
+            status_code=404, detail=f"Report with if '{report_id}' not found"
+        )
+    update.apply_to(original)
+    session.add(original)
+    session.commit()
+    session.refresh(original)
+    return ReportResponse.from_report(original)
+
+
+@app.delete("/api/report/{report_id}")
+def delete_report(
+    report_id: int,
+    session: SessionDep,
+):
+    original = session.exec(
+        select(Report).where(Report.report_id == report_id).offset(0).limit(1)
+    ).first()
+    if not original:
+        raise HTTPException(
+            status_code=404, detail=f"Report with if '{report_id}' not found"
+        )
+    session.delete(original)
+    session.commit()
+    return ReportResponse.from_report(original)
 
 
 @app.get("/api/report/{report_id}/page")

--- a/da-project-backend/app/api.py
+++ b/da-project-backend/app/api.py
@@ -17,6 +17,7 @@ from .models import (
     CommentCreate,
     CommentResponse,
     Page,
+    PageCreate,
     PageResponse,
     Report,
     ReportCreate,
@@ -103,6 +104,19 @@ def get_report_page(
     if not page:
         raise HTTPException(status_code=404, detail="Report page not found")
     return PageResponse.from_page(page)
+
+
+@app.post("/api/report/{report_id}/page")
+def add_report_page(
+    report_id: int,
+    page: PageCreate,
+    session: SessionDep,
+):
+    db_page = page.validate_to_page(report_id)
+    session.add(db_page)
+    session.commit()
+    session.refresh(db_page)
+    return PageResponse.from_page(db_page)
 
 
 @app.get("/api/report/{report_id}/page/{page_id}/comments")

--- a/da-project-backend/app/api.py
+++ b/da-project-backend/app/api.py
@@ -73,7 +73,9 @@ def get_report(
         select(Report).where(Report.report_id == report_id).offset(0).limit(1)
     ).first()
     if not report:
-        raise HTTPException(status_code=404, detail="Report not found")
+        raise HTTPException(
+            status_code=404, detail=f"Report with if '{report_id}' not found"
+        )
     return ReportResponse.from_report(report)
 
 
@@ -107,7 +109,7 @@ def delete_report(
     ).first()
     if not original:
         raise HTTPException(
-            status_code=404, detail=f"Report with if '{report_id}' not found"
+            status_code=404, detail=f"Report with id '{report_id}' not found"
         )
     session.delete(original)
     session.commit()
@@ -154,7 +156,10 @@ def get_report_page(
         .limit(1)
     ).first()
     if not page:
-        raise HTTPException(status_code=404, detail="Report page not found")
+        raise HTTPException(
+            status_code=404,
+            detail=f"Page from report '{report_id}' with id '{page_id}' not found",
+        )
     return PageResponse.from_page(page)
 
 
@@ -173,7 +178,8 @@ def update_report_page(
     ).first()
     if not original:
         raise HTTPException(
-            status_code=404, detail=f"Report with if '{report_id}' not found"
+            status_code=404,
+            detail=f"Page from report '{report_id}' with id '{page_id}' not found",
         )
     update.apply_to(original)
     session.add(original)
@@ -196,14 +202,15 @@ def delete_report_page(
     ).first()
     if not original:
         raise HTTPException(
-            status_code=404, detail=f"Report with if '{report_id}' not found"
+            status_code=404,
+            detail=f"Page from report '{report_id}' with id '{page_id}' not found",
         )
     session.delete(original)
     session.commit()
     return PageResponse.from_page(original)
 
 
-@app.get("/api/report/{report_id}/page/{page_id}/comments")
+@app.get("/api/report/{report_id}/page/{page_id}/comment")
 def get_all_report_page_comments(
     report_id: int,
     page_id: int,
@@ -221,7 +228,7 @@ def get_all_report_page_comments(
     return CommentResponse.from_comments(comments)
 
 
-@app.post("/api/report/{report_id}/page/{page_id}/comments")
+@app.post("/api/report/{report_id}/page/{page_id}/comment")
 def add_report_page_comment(
     report_id: int,
     page_id: int,
@@ -233,7 +240,8 @@ def add_report_page_comment(
     ).first()
     if not exists:
         raise HTTPException(
-            status_code=404, detail=f"Report with id '{report_id}' not found"
+            status_code=404,
+            detail=f"Page from report '{report_id}' with id '{page_id}' not found",
         )
     db_comment = comment.validate_to_comment(page_id)
     session.add(db_comment)

--- a/da-project-backend/app/api.py
+++ b/da-project-backend/app/api.py
@@ -16,6 +16,7 @@ from .models import (
     Comment,
     CommentCreate,
     CommentResponse,
+    CommentUpdate,
     Page,
     PageCreate,
     PageResponse,
@@ -248,6 +249,65 @@ def add_report_page_comment(
     session.commit()
     session.refresh(db_comment)
     return CommentResponse.from_comment(db_comment)
+
+
+@app.patch("/api/report/{report_id}/page/{page_id}/comment/{comment_id}")
+def update_report_page_comment(
+    report_id: int,
+    page_id: int,
+    comment_id: int,
+    update: CommentUpdate,
+    session: SessionDep,
+):
+    original = session.exec(
+        select(Comment)
+        .join(Page)
+        .where(
+            Page.report_id == report_id,
+            Comment.page_id == page_id,
+            Comment.comment_id == comment_id,
+        )
+        .offset(0)
+        .limit(1)
+    ).first()
+    if not original:
+        raise HTTPException(
+            status_code=404,
+            detail=f"Comment from report '{report_id}' page '{page_id}' with id '{comment_id}' not found",
+        )
+    update.apply_to(original)
+    session.add(original)
+    session.commit()
+    session.refresh(original)
+    return CommentResponse.from_comment(original)
+
+
+@app.delete("/api/report/{report_id}/page/{page_id}/comment/{comment_id}")
+def delete_report_page_comment(
+    report_id: int,
+    page_id: int,
+    comment_id: int,
+    session: SessionDep,
+):
+    original = session.exec(
+        select(Comment)
+        .join(Page)
+        .where(
+            Page.report_id == report_id,
+            Comment.page_id == page_id,
+            Comment.comment_id == comment_id,
+        )
+        .offset(0)
+        .limit(1)
+    ).first()
+    if not original:
+        raise HTTPException(
+            status_code=404,
+            detail=f"Comment from report '{report_id}' page '{page_id}' with id '{comment_id}' not found",
+        )
+    session.delete(original)
+    session.commit()
+    return CommentResponse.from_comment(original)
 
 
 @app.get("/api/report/{report_id}/page/{page_id}/column")

--- a/da-project-backend/app/models.py
+++ b/da-project-backend/app/models.py
@@ -98,6 +98,17 @@ class PageFields(SQLModel):
     chart_type: PageChartType = Field(sa_column=Col(Enum(PageChartType)))
     labels: str = Field(default="")
 
+    def to_page(self) -> "Page":
+        valid = self.model_validate(self)
+        return Page(
+            page_id=valid.page_id,
+            report_id=valid.report_id,
+            page_name=valid.page_name,
+            page_overview=valid.page_overview,
+            chart_type=valid.chart_type,
+            labels=valid.labels,
+        )
+
 
 class Page(PageFields, table=True):
     report: Report = Relationship(back_populates="pages")
@@ -124,6 +135,22 @@ class PageResponse(BaseModel):
     @staticmethod
     def from_pages(pages: Sequence[Page]) -> "List[PageResponse]":
         return [PageResponse.from_page(page) for page in pages]
+
+
+class PageCreate(BaseModel):
+    name: str
+    overview: str
+    chart_type: PageChartType
+    labels: str
+
+    def validate_to_page(self, report_id: int) -> Page:
+        return PageFields(
+            report_id=report_id,
+            page_name=self.name,
+            page_overview=self.overview,
+            chart_type=self.chart_type,
+            labels=self.labels,
+        ).to_page()
 
 
 ## COLUMN MODELS

--- a/da-project-backend/app/models.py
+++ b/da-project-backend/app/models.py
@@ -282,11 +282,11 @@ class CommentResponse(BaseModel):
 
 
 class CommentCreate(BaseModel):
-    remark: str
+    comment: str
 
     def validate_to_comment(self, page_id: int) -> Comment:
         return CommentFields(
-            comment=self.remark,
+            comment=self.comment,
             page_id=page_id,
             created_at=datetime.now(),
             updated_at=datetime.now(),

--- a/da-project-backend/app/models.py
+++ b/da-project-backend/app/models.py
@@ -291,3 +291,13 @@ class CommentCreate(BaseModel):
             created_at=datetime.now(),
             updated_at=datetime.now(),
         ).to_comment()
+
+
+class CommentUpdate(BaseModel):
+    comment: str | None = None
+
+    def apply_to(self, original: Comment):
+        if self.comment is not None:
+            original.comment = self.comment
+            original.updated_at = datetime.now()
+        original.model_validate(original)

--- a/da-project-backend/app/models.py
+++ b/da-project-backend/app/models.py
@@ -165,6 +165,24 @@ class PageCreate(BaseModel):
         ).to_page()
 
 
+class PageUpdate(BaseModel):
+    name: str | None = None
+    overview: str | None = None
+    chart_type: PageChartType | None = None
+    labels: str | None = None
+
+    def apply_to(self, original: Page):
+        if self.name is not None:
+            original.page_name = self.name
+        if self.overview is not None:
+            original.page_overview = self.overview
+        if self.chart_type is not None:
+            original.chart_type = self.chart_type
+        if self.labels is not None:
+            original.labels = self.labels
+        original.model_validate(original)
+
+
 ## COLUMN MODELS
 class ColumnDataType(enum.StrEnum):
     BOOLEAN = "BOOLEAN"

--- a/da-project-backend/app/models.py
+++ b/da-project-backend/app/models.py
@@ -82,6 +82,18 @@ class ReportCreate(BaseModel):
         ).to_report()
 
 
+class ReportUpdate(BaseModel):
+    overview: str | None = None
+    csv: str | None = None
+
+    def apply_to(self, original: Report):
+        if self.overview is not None:
+            original.report_overview = self.overview
+        if self.csv is not None:
+            original.raw_csv = self.csv
+        original.model_validate(original)
+
+
 ## PAGE MODELS
 class PageChartType(enum.StrEnum):
     BAR_CHART = "BAR_CHART"


### PR DESCRIPTION
closes #11 
closes #12 
closes #13

---

## changes
1. add CRUD APIs for `Report`s
   - currently, it is not returning csv since it can grow relatively. it only returns id and report overview
2. complete CRUD API for destructible entitires (aka not `Column`)
3. rename `/report-page` apis to `/report/{report_id}/page`
   - this is to use `report_id` in validation

## etc
- updated 404 error messages to include IDs for debugging at least (probably not useful for client-side)