### PR TITLE
Feat/proper add report api

### DIFF
--- a/da-project-backend/app/api.py
+++ b/da-project-backend/app/api.py
@@ -492,13 +492,29 @@ def _handle_number_column(
 
 @app.post("/api/gemini")
 def prompt_gemini(
-    prompt: str,
     _: SessionDep,
+    *,
+    prompt: str,
+    context: dict[str, str] = {},
     model: Literal[
         "gemini-1.5-flash",
         "gemini-1.5-flash-8b",
         "gemini-1.5-pro",
     ] = "gemini-1.5-flash",
 ):
+    prompt = f"""
+<system>
+Since this request comes from an API, I expect to only get the answer without acknowledgement from you.
+Keep it professional. Do not hallucinate.
+</system>
+<prompt>
+{prompt}
+</prompt>"""
+    for tag, content in context.items():
+        prompt += f"""
+<{tag}>
+{content}
+</{tag}>
+"""
     res = genai.GenerativeModel(model).generate_content(prompt)
     return res.text

--- a/da-project-backend/app/api.py
+++ b/da-project-backend/app/api.py
@@ -1,4 +1,3 @@
-import enum
 from collections import Counter
 from contextlib import asynccontextmanager
 from typing import Annotated, List, Literal
@@ -12,7 +11,6 @@ from .database import SessionDep, create_db_and_tables
 from .models import (
     Column,
     ColumnCreate,
-    ColumnDataType,
     ColumnResponse,
     Comment,
     CommentCreate,
@@ -28,6 +26,7 @@ from .models import (
     ReportUpdate,
     ReportWithColumnsResponse,
 )
+from .types import ColumnDataType, ColumnOperation
 
 
 @asynccontextmanager
@@ -329,7 +328,7 @@ def delete_report_page_comment(
 
 
 @app.get("/api/report/{report_id}/column")
-def get_report_page_columns(
+def get_report_columns(
     report_id: int,
     session: SessionDep,
     labels: str | None = None,
@@ -355,17 +354,6 @@ def get_report_page_columns(
     ]
 
 
-class ColumnOperation(enum.StrEnum):
-    FIRST = "first"
-    LAST = "last"
-    MAX = "max"
-    MEAN = "mean"
-    MEDIAN = "median"
-    MIN = "min"
-    MODE = "mode"
-    SUM = "sum"
-
-
 @app.get(
     "/api/report/{report_id}/column/{label}",
     description=r"""
@@ -387,7 +375,7 @@ return a 422 Unprocessable Content
 | sum | number | number |
 """,
 )
-def get_report_page_column_data_by_label(
+def get_report_column_data_by_label(
     report_id: int,
     label: str,
     session: SessionDep,

--- a/da-project-backend/app/api.py
+++ b/da-project-backend/app/api.py
@@ -104,7 +104,7 @@ def update_report(
     report_id: int,
     update: ReportUpdate,
     session: SessionDep,
-):
+) -> ReportResponse:
     original = session.exec(
         select(Report).where(Report.report_id == report_id).offset(0).limit(1),
     ).first()
@@ -124,7 +124,7 @@ def update_report(
 def delete_report(
     report_id: int,
     session: SessionDep,
-):
+) -> ReportResponse:
     original = session.exec(
         select(Report).where(Report.report_id == report_id).offset(0).limit(1),
     ).first()
@@ -156,7 +156,7 @@ def add_report_page(
     report_id: int,
     page: PageCreate,
     session: SessionDep,
-):
+) -> PageResponse:
     columns = get_report_columns(report_id, session, page.labels)
     columns_ctx = "\n".join(
         list(
@@ -209,7 +209,7 @@ def update_report_page(
     page_id: int,
     update: PageUpdate,
     session: SessionDep,
-):
+) -> PageResponse:
     original = session.exec(
         select(Page)
         .where(Page.report_id == report_id, Page.page_id == page_id)
@@ -233,7 +233,7 @@ def delete_report_page(
     report_id: int,
     page_id: int,
     session: SessionDep,
-):
+) -> PageResponse:
     original = session.exec(
         select(Page)
         .where(Page.report_id == report_id, Page.page_id == page_id)
@@ -297,7 +297,7 @@ def update_report_page_comment(
     comment_id: int,
     update: CommentUpdate,
     session: SessionDep,
-):
+) -> CommentResponse:
     original = session.exec(
         select(Comment)
         .join(Page)
@@ -327,7 +327,7 @@ def delete_report_page_comment(
     page_id: int,
     comment_id: int,
     session: SessionDep,
-):
+) -> CommentResponse:
     original = session.exec(
         select(Comment)
         .join(Page)
@@ -523,7 +523,7 @@ def prompt_gemini(
         "gemini-1.5-flash-8b",
         "gemini-1.5-pro",
     ] = "gemini-1.5-flash",
-):
+) -> str:
     prompt = f"""
 <system>
 Since this request comes from an API, I expect to only get the answer without acknowledgement from you.

--- a/da-project-backend/app/api.py
+++ b/da-project-backend/app/api.py
@@ -65,7 +65,8 @@ def add_report(
     ).validate_to_report()
     db_report.report_overview = prompt_gemini(
         session,
-        prompt="Give an overview of this report",
+        prompt="Given this data and a hypothetical report made using it, give"
+        "an overview of the report as if it is already done.",
         context={"data": db_report.clean_csv},
     )
     session.add(db_report)
@@ -168,7 +169,8 @@ def add_report_page(
     )
     overview = prompt_gemini(
         session,
-        prompt="Give an overview of this report page.",
+        prompt="Given this data and a hypothetical report page made using it, "
+        "give an overview of the report page as if it is already done.",
         context={
             "page_name": page.name,
             "columns": columns_ctx,
@@ -526,8 +528,9 @@ def prompt_gemini(
 ) -> str:
     prompt = f"""
 <system>
-Since this request comes from an API, I expect to only get the answer without acknowledgement from you.
-Keep it professional. Do not hallucinate.
+Since this request comes from an API, I expect to only get the answer without
+acknowledgement from you. Do not use unsure tone and terms such as "likely",
+"probably", etc. Keep it professional. Do not hallucinate.
 </system>
 <prompt>
 {prompt}

--- a/da-project-backend/app/field_types.py
+++ b/da-project-backend/app/field_types.py
@@ -1,0 +1,14 @@
+from enum import StrEnum
+
+
+class PageChartType(StrEnum):
+    BAR_CHART = "BAR_CHART"
+    PIE_CHART = "PIE_CHART"
+    TREND_CHART = "TREND_CHART"
+    SCATTER_PLOT = "SCATTER_PLOT"
+
+
+class ColumnDataType(StrEnum):
+    BOOLEAN = "BOOLEAN"
+    NUMBER = "NUMBER"
+    STRING = "STRING"

--- a/da-project-backend/app/models.py
+++ b/da-project-backend/app/models.py
@@ -80,7 +80,6 @@ class ReportResponse(BaseModel):
 
 class ReportCreate(BaseModel):
     name: str
-    overview: str
     csv_upload: UploadFile
     model_config = {"extra": "forbid"}
 
@@ -99,7 +98,6 @@ class ReportCreate(BaseModel):
         return (
             ReportFields(
                 report_name=self.name,
-                report_overview=self.overview,
                 clean_csv=cleaned_csv,
             ).to_report(),
             labels,
@@ -178,15 +176,14 @@ class PageResponse(BaseModel):
 
 class PageCreate(BaseModel):
     name: str
-    overview: str
     chart_type: PageChartType
     labels: str
 
-    def validate_to_page(self, report_id: int) -> Page:
+    def validate_to_page(self, report_id: int, overview: str) -> Page:
         return PageFields(
             report_id=report_id,
             page_name=self.name,
-            page_overview=self.overview,
+            page_overview=overview,
             chart_type=self.chart_type,
             labels=self.labels,
         ).to_page()

--- a/da-project-backend/app/models.py
+++ b/da-project-backend/app/models.py
@@ -95,13 +95,6 @@ class ReportUpdate(BaseModel):
 
 
 ## PAGE MODELS
-class PageChartType(enum.StrEnum):
-    BAR_CHART = "BAR_CHART"
-    PIE_CHART = "PIE_CHART"
-    TREND_CHART = "TREND_CHART"
-    SCATTER_PLOT = "SCATTER_PLOT"
-
-
 class PageFields(SQLModel):
     page_id: int | None = Field(default=None, primary_key=True)
     report_id: int = Field(foreign_key="report.report_id", ondelete="CASCADE")
@@ -184,12 +177,6 @@ class PageUpdate(BaseModel):
 
 
 ## COLUMN MODELS
-class ColumnDataType(enum.StrEnum):
-    BOOLEAN = "BOOLEAN"
-    NUMBER = "NUMBER"
-    STRING = "STRING"
-
-
 class ColumnFields(SQLModel):
     column_id: int | None = Field(default=None, primary_key=True)
     report_id: int = Field(foreign_key="report.report_id", ondelete="CASCADE")

--- a/da-project-backend/app/models.py
+++ b/da-project-backend/app/models.py
@@ -14,7 +14,7 @@ from sqlmodel import (
 )
 from sqlmodel import Column as Col
 
-from .field_types import ColumnDataType, PageChartType
+from .types import ColumnDataType, PageChartType
 
 """
 MODEL STRUCTURE
@@ -94,7 +94,7 @@ class ReportCreate(BaseModel):
         - csv column dtype
         """
         cleaned_csv, labels, rows, dtypes = clean_csv(
-            self.csv_upload.file.read().decode()
+            self.csv_upload.file.read().decode(),
         )
         return (
             ReportFields(

--- a/da-project-backend/app/types.py
+++ b/da-project-backend/app/types.py
@@ -1,6 +1,7 @@
 from enum import StrEnum
 
 
+## MODEL TYPES
 class PageChartType(StrEnum):
     BAR_CHART = "BAR_CHART"
     PIE_CHART = "PIE_CHART"
@@ -12,3 +13,15 @@ class ColumnDataType(StrEnum):
     BOOLEAN = "BOOLEAN"
     NUMBER = "NUMBER"
     STRING = "STRING"
+
+
+## API TYPES
+class ColumnOperation(StrEnum):
+    FIRST = "first"
+    LAST = "last"
+    MAX = "max"
+    MEAN = "mean"
+    MEDIAN = "median"
+    MIN = "min"
+    MODE = "mode"
+    SUM = "sum"

--- a/da-project-backend/process/clean.py
+++ b/da-project-backend/process/clean.py
@@ -2,8 +2,7 @@ from io import StringIO
 
 import polars as pl
 import polars.datatypes as dtype
-
-from app.field_types import ColumnDataType
+from app.types import ColumnDataType
 
 BOOLEAN_TRUE_VALUES = {"true", "yes", "y", "on"}
 BOOLEAN_FALSE_VALUES = {"false", "no", "n", "off"}

--- a/da-project-backend/process/clean.py
+++ b/da-project-backend/process/clean.py
@@ -1,0 +1,62 @@
+from io import StringIO
+
+import polars as pl
+import polars.datatypes as dtype
+
+from app.field_types import ColumnDataType
+
+BOOLEAN_TRUE_VALUES = {"true", "yes", "y", "on"}
+BOOLEAN_FALSE_VALUES = {"false", "no", "n", "off"}
+
+
+def clean_csv(
+    file_contents: str,
+) -> tuple[str, list[str], list[str], list[ColumnDataType]]:
+    """Returns:
+    - cleaned csv string
+    - cleaned csv labels
+    - cleaned csv rows as comma separated string
+    - cleaned csv dtype
+    """
+    df = pl.read_csv(StringIO(file_contents))
+    labels = []
+    rows = []
+    dtypes: list[ColumnDataType] = []
+    for col in df.get_columns():
+        df = df.with_columns(
+            col.cast(dtype.String).str.to_lowercase().str.strip_chars().alias(col.name),
+        )
+        og_dtype = col.dtype
+        col = df.get_column(col.name)
+        match og_dtype:
+            case dtype.String | dtype.Categorical | dtype.Enum | dtype.Utf8:
+                string_vals = col.to_list()
+                true_count = sum(1 for x in string_vals if x in BOOLEAN_TRUE_VALUES)
+                false_count = sum(1 for x in string_vals if x in BOOLEAN_FALSE_VALUES)
+                total_count = len(string_vals)
+                possibly_bool_column = true_count + false_count > total_count * 0.8
+                if possibly_bool_column:
+                    df = df.with_columns(col.is_in(BOOLEAN_TRUE_VALUES).alias(col.name))
+                    dtypes.append(ColumnDataType.BOOLEAN)
+                else:
+                    dtypes.append(ColumnDataType.STRING)
+            case dtype.Boolean:
+                dtypes.append(ColumnDataType.BOOLEAN)
+            case (
+                dtype.Decimal
+                | dtype.Float32
+                | dtype.Float64
+                | dtype.Int8
+                | dtype.Int16
+                | dtype.Int32
+                | dtype.Int64
+                | dtype.UInt8
+                | dtype.UInt16
+                | dtype.UInt32
+                | dtype.UInt64
+            ):
+                dtypes.append(ColumnDataType.NUMBER)
+        col = df.get_column(col.name)
+        labels.append(col.name)
+        rows.append(",".join(col.cast(dtype.String).to_list()))
+    return df.write_csv(), labels, rows, dtypes

--- a/da-project-backend/process/read.py
+++ b/da-project-backend/process/read.py
@@ -5,6 +5,6 @@ import polars as pl
 
 
 def read_csv(file_contents: bytes) -> list[dict[str, Any]]:
-    "reads csv from uploaded file and returns list of rows as dicts"
+    """Reads csv from uploaded file and returns list of rows as dicts"""
     df = pl.read_csv(io.BytesIO(file_contents))
     return df.to_dicts()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,6 +9,7 @@ dependencies = [
     "google-generativeai>=0.8.3",
     "polars>=1.12.0",
     "python-dotenv>=1.0.1",
+    "python-multipart>=0.0.17",
     "ruff>=0.7.3",
     "sqlmodel>=0.0.22",
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -114,6 +114,7 @@ dependencies = [
     { name = "google-generativeai" },
     { name = "polars" },
     { name = "python-dotenv" },
+    { name = "python-multipart" },
     { name = "ruff" },
     { name = "sqlmodel" },
 ]
@@ -124,6 +125,7 @@ requires-dist = [
     { name = "google-generativeai", specifier = ">=0.8.3" },
     { name = "polars", specifier = ">=1.12.0" },
     { name = "python-dotenv", specifier = ">=1.0.1" },
+    { name = "python-multipart", specifier = ">=0.0.17" },
     { name = "ruff", specifier = ">=0.7.3" },
     { name = "sqlmodel", specifier = ">=0.0.22" },
 ]


### PR DESCRIPTION
closes #15 

---

## changes
1. creating a `report` now requires uploading a csv file
2. creating a `report` now cleans the csv file and create `column` entries based on the cleaned csv
   - cleaning csv tries to detect if a column is a booelan column and standardizes the values to `true | false`
3. creating both `report` and `page` gets their overview generated by gemini (see demos)
4. `column` APIs now do not rely on `page`'s `page_id` (e.g., `/api/report/{id}/column` instead of `/api/report/{report_id}/page/{page_id}/column`
   - in the first place, `page` has nothing to do with `column`s


## demos
### creating report through uploading csv file. overview generated by gemini
https://github.com/user-attachments/assets/322e5332-d322-4778-ad1f-f6aa89ade712

### creating report page. overview generated by gemini
https://github.com/user-attachments/assets/225ad92a-2846-46d5-91dd-b39d6729e649

## etc
- put types used in model fields and api requests into a unified `types.py`. its small for now so it suffices