### PR TITLE
Feat/preview clean csv

### DIFF
--- a/da-project-backend/app/api/__init__.py
+++ b/da-project-backend/app/api/__init__.py
@@ -9,6 +9,7 @@ from app.database import create_db_and_tables
 
 from .column import router as column
 from .comment import router as comment
+from .csv import router as csv
 from .gemini import router as gemini
 from .page import router as page
 from .report import router as report
@@ -56,3 +57,4 @@ app.include_router(page)
 app.include_router(column)
 app.include_router(comment)
 app.include_router(gemini)
+app.include_router(csv)

--- a/da-project-backend/app/api/csv.py
+++ b/da-project-backend/app/api/csv.py
@@ -1,0 +1,16 @@
+from typing import Annotated
+
+from fastapi import APIRouter, File
+
+from app.database import SessionDep
+from app.models import CleanColumnData, RawCsv
+
+router = APIRouter(prefix="/api/csv", tags=["CSV Handling"])
+
+
+@router.post("/clean")
+def preview_clean_csv(
+    raw_csv: Annotated[RawCsv, File()],
+    _: SessionDep,
+) -> list[CleanColumnData]:
+    return raw_csv.to_clean_columns()

--- a/da-project-backend/app/api/report.py
+++ b/da-project-backend/app/api/report.py
@@ -34,10 +34,7 @@ def add_report(
     report: Annotated[ReportCreate, File()],
     session: SessionDep,
 ) -> ReportWithColumnsResponse:
-    db_report, labels, rows, dtypes = ReportCreate(
-        name=report.name,
-        csv_upload=report.csv_upload,
-    ).validate_to_report()
+    db_report, labels, rows, dtypes = report.validate_to_report()
     db_report.report_overview = prompt_gemini(
         session,
         prompt="Given this data and a hypothetical report made using it, give"

--- a/da-project-backend/app/models.py
+++ b/da-project-backend/app/models.py
@@ -14,7 +14,7 @@ from sqlmodel import (
 )
 from sqlmodel import Column as Col
 
-from .types import ColumnDataType, PageChartType
+from app.types import ColumnDataType, PageChartType
 
 """
 MODEL STRUCTURE
@@ -362,3 +362,35 @@ class CommentUpdate(BaseModel):
             original.comment = self.comment
             original.updated_at = datetime.now()
         original.model_validate(original)
+
+
+"""
+************************************
+BELOW ARE MODELS THAT ARE NOT FOR DB
+************************************
+"""
+
+
+class RawCsv(BaseModel):
+    csv_upload: UploadFile
+
+    def to_clean_columns(
+        self,
+    ) -> list["CleanColumnData"]:
+        _, labels, rows, dtypes = clean_csv(
+            self.csv_upload.file.read().decode(),
+        )
+        return [
+            CleanColumnData(
+                label=label,
+                column_type=col_type,
+                rows=[data for data in row_data.split(",")],
+            )
+            for (label, row_data, col_type) in zip(labels, rows, dtypes)
+        ]
+
+
+class CleanColumnData(BaseModel):
+    label: str
+    column_type: ColumnDataType
+    rows: list[str]


### PR DESCRIPTION
closes #20 

---

## changes
1. upload csv to preview cleaned contents

## demo
https://github.com/user-attachments/assets/a6834e58-9176-44c5-b486-f8e7357a9ebb

## todo
1. use the response here as the clean csv parameter for `POST /api/report` in creating a report. This is to avoid redundant cleaning. 
    - Currently, you're supposed to upload the raw csv for both the preview and the report creation, triggering the cleaning process twice

