### PR TITLE
Feat/use cleaned csv in creating report

### DIFF
--- a/da-project-backend/app/api/report.py
+++ b/da-project-backend/app/api/report.py
@@ -1,6 +1,6 @@
 from typing import Annotated, List
 
-from fastapi import APIRouter, File, HTTPException, Query
+from fastapi import APIRouter, HTTPException, Query
 from sqlmodel import select
 
 from app.database import SessionDep
@@ -31,7 +31,7 @@ def get_all_reports(
 
 @router.post("/")
 def add_report(
-    report: Annotated[ReportCreate, File()],
+    report: ReportCreate,
     session: SessionDep,
 ) -> ReportWithColumnsResponse:
     db_report, labels, rows, dtypes = report.validate_to_report()


### PR DESCRIPTION
closes #22 

---

## changes
1. `POST /api/report` report creation API does not accept file uploads. Request body now expects the cleaned csv response from `POST /api/csv/clean`

## demo
https://github.com/user-attachments/assets/5460485b-c6b7-440c-b75a-6ef57fae94bc