### PR TITLE
Feat/fill null strategy from user

### DIFF
--- a/da-project-backend/app/api/csv.py
+++ b/da-project-backend/app/api/csv.py
@@ -1,4 +1,4 @@
-from typing import Annotated
+from typing import Annotated, Literal
 
 from fastapi import APIRouter, File
 
@@ -12,5 +12,8 @@ router = APIRouter(prefix="/api/csv", tags=["CSV Handling"])
 def preview_clean_csv(
     raw_csv: Annotated[RawCsv, File()],
     _: SessionDep,
+    strategy: Literal[
+        "forward", "backward", "min", "max", "mean", "zero", "one"
+    ] = "zero",
 ) -> list[CleanColumnData]:
-    return raw_csv.to_clean_columns()
+    return raw_csv.to_clean_columns(strategy)

--- a/da-project-backend/app/models.py
+++ b/da-project-backend/app/models.py
@@ -1,7 +1,7 @@
 import csv
 from datetime import datetime
 from io import StringIO
-from typing import List, Sequence
+from typing import List, Literal, Sequence
 
 from fastapi import UploadFile
 from process.clean import clean_csv
@@ -385,9 +385,11 @@ class RawCsv(BaseModel):
 
     def to_clean_columns(
         self,
+        strategy: Literal["forward", "backward", "min", "max", "mean", "zero", "one"],
     ) -> list["CleanColumnData"]:
         _, labels, rows, dtypes = clean_csv(
             self.csv_upload.file.read().decode(),
+            strategy,
         )
         return [
             CleanColumnData(

--- a/da-project-backend/app/types.py
+++ b/da-project-backend/app/types.py
@@ -26,3 +26,13 @@ class ColumnOperation(StrEnum):
     MIN = "min"
     MODE = "mode"
     SUM = "sum"
+
+
+class FillNullStrategy(StrEnum):
+    FORWARD = "forward"
+    BACKWARD = "backward"
+    MIN = "min"
+    MAX = "max"
+    MEAN = "mean"
+    ZERO = "zero"
+    ONE = "one"

--- a/da-project-backend/process/clean.py
+++ b/da-project-backend/process/clean.py
@@ -1,4 +1,5 @@
 from io import StringIO
+from typing import Literal
 
 import polars as pl
 import polars.datatypes as dtype
@@ -10,6 +11,7 @@ BOOLEAN_FALSE_VALUES = {"false", "no", "n", "off"}
 
 def clean_csv(
     file_contents: str,
+    strategy: Literal["forward", "backward", "min", "max", "mean", "zero", "one"],
 ) -> tuple[str, list[str], list[str], list[ColumnDataType]]:
     """Returns:
     - cleaned csv string
@@ -21,7 +23,7 @@ def clean_csv(
         StringIO(
             remove_comma_inside_quotes(file_contents),
         ),
-    ).fill_null(strategy="zero")
+    ).fill_null(strategy=strategy)
     labels = []
     rows = []
     dtypes: list[ColumnDataType] = []


### PR DESCRIPTION
### changes
1. request body for csv cleaning has a query param `strategy` so the user can specify which fill null strategy to use when handling null values (default: `zero`)
2. labels get stripped of whitespaces now

### demo
https://github.com/user-attachments/assets/566f203b-7d27-4615-a75a-7cb060d16417


