### PR TITLE
Feat/simple spelling error cleaning

### DIFF
--- a/da-project-backend/process/clean.py
+++ b/da-project-backend/process/clean.py
@@ -7,6 +7,7 @@ from app.types import ColumnDataType, CurrencySymbol
 
 BOOLEAN_TRUE_VALUES = {"true", "yes", "y", "on"}
 BOOLEAN_FALSE_VALUES = {"false", "no", "n", "off"}
+COUNT_THRESHOLD = 0.8
 
 
 def clean_csv(
@@ -101,15 +102,15 @@ def possibly_bool_column(string_vals: list[str]) -> bool:
     true_count = sum(1 for x in string_vals if x in BOOLEAN_TRUE_VALUES)
     false_count = sum(1 for x in string_vals if x in BOOLEAN_FALSE_VALUES)
     total_count = len(string_vals)
-    return true_count + false_count > total_count * 0.8
+    return true_count + false_count > total_count * COUNT_THRESHOLD
 
 
 def possibly_currency_column(string_vals: list[str]) -> CurrencySymbol | None:
     "returns currency symbol if found. None if none"
+    threshold = len(string_vals) * COUNT_THRESHOLD
     ret: CurrencySymbol | None = None
     currency_symbol: CurrencySymbol | None = None
     found_count = 0
-    threshold = len(string_vals) * 0.8
     for val in string_vals:
         if val in [""]:
             continue


### PR DESCRIPTION
## minor spelling error cleaning algo (done using string similarity)
1. check against mode first before trying to compare against other column vals; return if similar enough
2. accumulate similar enough column vals
3. return most occuring in accumulated similar vals if any
4. otherwise just return the original

## limitations
1. only minor spelling mistakes
    - `male` and `female` are not in the threshold of similar enough for `male` to be a spelling mistake for `female`. Similarly, `pissa` and `pizza` are also not in the threshold of similar enough, even though `pissa` may be a legitimate spelling mistake. `bilgy` and `Biology` are similar enough though so it can correct that.
2. exaggerates data cleanliness/dirtiness
    - To correct these minor spelling mistakes, it assumes that there are others in the column that it can use as reference. If the dataset is a bit dirty to relatively clean, this should handle it fine. But it can also exaggerate already dirty datasets.
    - Earlier, I said that `bilgy` can be corrected to `Biology`. Well, so can the other way around. If there is more than 1 `Biology` entry, `bilgy` will be converted to it. However, the same goes for the opposite; if there is more than 1 `bilgy`, `Biology` will be converted to it. If there is 1 `bilgy` and 1 `Biology`, the "correct" one will be whoever came first in the column.

## demo
https://github.com/user-attachments/assets/19b1be7b-551c-4c92-9d12-4d40c245a5d3



